### PR TITLE
fix: 实现对文字修饰的render支持

### DIFF
--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -120,6 +120,7 @@ const generateText = async (node: Root, result: TextNode & { [key: string]: any 
     result.setRangeLineHeight(style.start, style.end, style.textStyle.lineHeight);
     result.setRangeFontSize(style.start, style.end, style.textStyle.fontSize);
     result.setRangeLetterSpacing(style.start, style.end, style.textStyle.letterSpacing)
+    result.setRangeTextDecoration(style.start, style.end, style.textStyle.textDecoration)
   })
   
 


### PR DESCRIPTION
当前的render方法中，没有处理text-decoration，显示效果异常。
具体如下，带划线文字的效果如下：
![image](https://github.com/mastergo-design/html-to-mastergo/assets/8678088/cb8bc3dd-b779-4d42-97ed-b82fdb20b739)
处理后效果如下：
![image](https://github.com/mastergo-design/html-to-mastergo/assets/8678088/57ee9478-c440-40e4-8fc1-84c9dab095ce)
